### PR TITLE
Sets up single post layout

### DIFF
--- a/_includes/post-image.html
+++ b/_includes/post-image.html
@@ -1,0 +1,1 @@
+<img src="https://via.placeholder.com/400x400" class="post__img" alt="Placeholder" title="Placeholder" />

--- a/_includes/post-image.html
+++ b/_includes/post-image.html
@@ -1,1 +1,4 @@
-<img src="https://via.placeholder.com/400x400" class="post__img" alt="Placeholder" title="Placeholder" />
+{%- if page.layout == 'post' -%}
+  {%- assign post = page -%}
+{%- endif -%}
+<img src="{{ post.image }}" class="post__img" alt="{{ post.image_caption }}" title="{{ post.image_caption }}" />

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -6,19 +6,26 @@ layout: default
   <header class="post__header">
     <h1 class="post__title" itemprop="name headline">{{ page.title | escape }}</h1>
     Content Type<br />
-    <section class="post__meta">
-      Authors<br />
-      Published<br />
-      Last Updated<br />
-      Photo Caption
-    </section>
-    Social Share
   </header>
-  <section class="post__image">Post Image</section>
+  <section class="post__meta">
+    Authors<br />
+    Published<br />
+    Last Updated<br />
+    Photo Caption
+    Social Share
+  </section>
+  <section class="post__img-container">
+    {% include post-image.html %}
+  </section>
   <aside class="post__sidebar">
-    Details<br />
-    Download<br />
-    Related Briefs<br />
+    <section class="post__img-container--large">
+      {% include post-image.html %}
+    </section>
+    <section class="post__details">
+      Details<br />
+      Download<br />
+      Related Briefs<br />
+    </section>
   </aside>
 
   <section class="post__content e-content" itemprop="articleBody">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -40,6 +40,6 @@ layout: default
     - Tags<br />
     - Related Posts
   </section>
-  {% include page-footer.html %}
   <a class="u-url" href="{{ page.url | relative_url }}" hidden></a>
 </article>
+{% include page-footer.html %}

--- a/_posts/2018-02-14-welcome-to-jekyll.markdown
+++ b/_posts/2018-02-14-welcome-to-jekyll.markdown
@@ -3,6 +3,10 @@ layout: post
 title:  "Welcome to Jekyll!"
 date:   2018-02-14 00:56:34 +0900
 categories: jekyll update
+image: https://via.placeholder.com/400x400
+image_caption: This is a test image caption
+image_source: This is a test image source
+
 ---
 You’ll find this post in your `_posts` directory. Go ahead and edit it and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.
 

--- a/assets/_sass/abstracts/_variables.scss
+++ b/assets/_sass/abstracts/_variables.scss
@@ -25,7 +25,7 @@ $color__gray-dark: #6d6d6d;
 $color__gray-darker: #555;
 $color__off-black: #333;
 
-$color__background-body: $color__white;
+$color__background-body: $color__blue-dark;
 $color__background-screen: $color__white;
 $color__background-hr: $color__black;
 $color__background-pre: #eee;
@@ -63,11 +63,11 @@ $size__wrapper-max-width: (
   'xlarge': calc(1312px - (56px * 2))
 );
 
-$size__wrapper-padding: (
+$size__content-padding: (
   'small': 20px,
   'medium': 5vw,
   'large': 6vw,
-  'xlarge': 0
+  'xlarge': calc((100% - 680px) / 2)
 );
 
 $size__sidebar-max-width: (
@@ -77,7 +77,7 @@ $size__sidebar-max-width: (
 
 $size__content-max-width: (
   'small': 100%,
-  'medium': calc(100% - (size($size__wrapper-padding, 'medium') * 2)),
-  'large': calc(100% - (size($size__wrapper-padding, 'large') * 2)),
+  'medium': calc(100% - (5vw * 2)),
+  'large': calc(100% - (6vw * 2)),
   'xlarge': 680px
 );

--- a/assets/_sass/base/_base.scss
+++ b/assets/_sass/base/_base.scss
@@ -33,7 +33,6 @@ body {
 .wrapper {
   max-width: size($size__wrapper-max-width, 'small');
   margin: 0 auto;
-  padding: 0 size($size__wrapper-padding, 'small');
 
   @include breakpoint('medium') {
     max-width: size($size__wrapper-max-width, 'medium');

--- a/assets/_sass/main.scss
+++ b/assets/_sass/main.scss
@@ -13,3 +13,5 @@
 @import 'base/base';
 
 @import 'components/buttons';
+
+@import 'pages/post';

--- a/assets/_sass/pages/_post.scss
+++ b/assets/_sass/pages/_post.scss
@@ -1,0 +1,90 @@
+/*============================
+=            Post            =
+============================*/
+
+.post {
+  display: grid;
+  grid-template-areas:
+    'header'
+    'image'
+    'sidebar'
+    'content'
+    'footer';
+  
+  @include breakpoint('large') {
+    grid-template-areas:
+      'image header'
+      'sidebar content'
+      'footer footer';
+    grid-template-columns: size($size__sidebar-max-width, 'large') auto;
+  }
+
+  &__header,
+  &__image,
+  &__sidebar,
+  &__content,
+  &__footer {
+    padding: 0 size($size__content-padding, 'small');
+  }
+  
+  &__header {
+    grid-area: header;
+    background-color: $color__white;
+
+    @include breakpoint('medium') {
+      padding: 0 size($size__content-padding, 'medium');
+    }
+
+    @include breakpoint('large') {
+      padding: 0 size($size__content-padding, 'large');
+    }
+
+    @include breakpoint('xlarge') {
+      $max-width: size($size__content-max-width, 'xlarge');
+      padding: 0 calc((100% - #{$max-width}) / 2);
+    }
+  }
+
+  &__image {
+    grid-area: image;
+    background-color: $color__blue;
+
+    @include breakpoint('large') {
+      margin-right: -3vw;
+    }
+
+    @include breakpoint('xlarge') {
+      margin-right: -96px;
+    }
+  }
+
+  &__sidebar {
+    grid-area: sidebar;
+    background-color: $color__off-white;
+  }
+
+  &__content {
+    grid-area: content;
+    width: 100%;
+    margin: 0 auto;
+    padding: 0 size($size__content-padding, 'small');
+    background-color: $color__white;
+
+    @include breakpoint('medium') {
+      padding: 0 size($size__content-padding, 'medium');
+    }
+
+    @include breakpoint('large') {
+      padding: 0 size($size__content-padding, 'large');
+    }
+
+    @include breakpoint('xlarge') {
+      padding: 0 size($size__content-padding, 'xlarge');
+    }
+  }
+
+  &__footer {
+    grid-area: footer;
+    background-color: $color__off-white;
+  }
+}

--- a/assets/_sass/pages/_post.scss
+++ b/assets/_sass/pages/_post.scss
@@ -87,8 +87,7 @@
   &__img {
     position: relative;
     display: block;
-    width: 100%;
-    height: auto;
+    max-width: 100%;
     line-height: 1;
   }
 

--- a/assets/_sass/pages/_post.scss
+++ b/assets/_sass/pages/_post.scss
@@ -3,8 +3,6 @@
 ============================*/
 
 .post {
-  $post: &;
-  
   @include breakpoint('medium') {
     display: grid;
     grid-template-areas:

--- a/assets/_sass/pages/_post.scss
+++ b/assets/_sass/pages/_post.scss
@@ -3,25 +3,38 @@
 ============================*/
 
 .post {
+  $post: &;
+
   display: grid;
   grid-template-areas:
     'header'
+    'meta'
     'image'
     'sidebar'
     'content'
     'footer';
   
+  @include breakpoint('medium') {
+    grid-template-areas:
+      'header header'
+      'meta image'
+      'sidebar sidebar'
+      'content content'
+      'footer footer';
+    grid-template-columns: auto 33%;
+  }
+  
   @include breakpoint('large') {
     grid-template-areas:
-      'image header'
+      'sidebar header'
+      'sidebar meta'
       'sidebar content'
-      'footer footer';
+      '. footer';
     grid-template-columns: size($size__sidebar-max-width, 'large') auto;
   }
 
   &__header,
-  &__image,
-  &__sidebar,
+  &__meta,
   &__content,
   &__footer {
     padding: 0 size($size__content-padding, 'small');
@@ -29,38 +42,70 @@
   
   &__header {
     grid-area: header;
-    background-color: $color__white;
+    color: $color__white;
+  }
 
+  &__meta {
+    grid-area: meta;
+    background-color: $color__white;
+  }
+
+  &__header,
+  &__meta {
     @include breakpoint('medium') {
-      padding: 0 size($size__content-padding, 'medium');
+      padding: 1rem size($size__content-padding, 'medium');
     }
 
     @include breakpoint('large') {
-      padding: 0 size($size__content-padding, 'large');
+      padding: 1rem size($size__content-padding, 'large');
     }
 
     @include breakpoint('xlarge') {
       $max-width: size($size__content-max-width, 'xlarge');
-      padding: 0 calc((100% - #{$max-width}) / 2);
+      padding: 1rem calc((100% - #{$max-width}) / 2);
     }
   }
 
-  &__image {
+  &__img-container {
     grid-area: image;
+    padding: 0;
     background-color: $color__blue;
 
     @include breakpoint('large') {
-      margin-right: -3vw;
+      display: none;
     }
 
-    @include breakpoint('xlarge') {
-      margin-right: -96px;
+    &--large {
+      display: none;
+
+      @include breakpoint('large') {
+        display: block;
+        margin-right: -3vw;
+      }
+
+      @include breakpoint('xlarge') {
+        margin-right: -96px;
+      }
+
     }
+  }
+
+  &__img {
+    position: relative;
+    display: block;
+    width: 100%;
+    height: auto;
+    line-height: 1;
   }
 
   &__sidebar {
     grid-area: sidebar;
+    align-self: start;
     background-color: $color__off-white;
+  }
+
+  &__details {
+    padding: size($size__content-padding, 'small');
   }
 
   &__content {

--- a/assets/_sass/pages/_post.scss
+++ b/assets/_sass/pages/_post.scss
@@ -4,17 +4,9 @@
 
 .post {
   $post: &;
-
-  display: grid;
-  grid-template-areas:
-    'header'
-    'meta'
-    'image'
-    'sidebar'
-    'content'
-    'footer';
   
   @include breakpoint('medium') {
+    display: grid;
     grid-template-areas:
       'header header'
       'meta image'
@@ -32,26 +24,26 @@
       '. footer';
     grid-template-columns: size($size__sidebar-max-width, 'large') auto;
   }
-
-  &__header,
-  &__meta,
-  &__content,
-  &__footer {
-    padding: 0 size($size__content-padding, 'small');
-  }
   
   &__header {
     grid-area: header;
+    padding: 0 size($size__content-padding, 'small');
     color: $color__white;
+
+    @include breakpoint('medium') {
+      padding: 0;
+    }
+
+    @include breakpoint('large') {
+      padding: 0 size($size__content-padding, 'large');
+    }
   }
 
   &__meta {
     grid-area: meta;
+    padding: size($size__content-padding, 'small');
     background-color: $color__white;
-  }
 
-  &__header,
-  &__meta {
     @include breakpoint('medium') {
       padding: 1rem size($size__content-padding, 'medium');
     }
@@ -59,7 +51,10 @@
     @include breakpoint('large') {
       padding: 1rem size($size__content-padding, 'large');
     }
+  }
 
+  &__header,
+  &__meta {
     @include breakpoint('xlarge') {
       $max-width: size($size__content-max-width, 'xlarge');
       padding: 1rem calc((100% - #{$max-width}) / 2);
@@ -69,7 +64,6 @@
   &__img-container {
     grid-area: image;
     padding: 0;
-    background-color: $color__blue;
 
     @include breakpoint('large') {
       display: none;
@@ -106,17 +100,26 @@
 
   &__details {
     padding: size($size__content-padding, 'small');
+
+    @include breakpoint('medium') {
+      padding: size($size__content-padding, 'small') size($size__content-padding, 'medium');
+    }
+
+    @include breakpoint('large') {
+      padding: size($size__content-padding, 'small');
+    }
   }
 
   &__content {
     grid-area: content;
     width: 100%;
     margin: 0 auto;
-    padding: 0 size($size__content-padding, 'small');
+    padding: size($size__content-padding, 'small');
     background-color: $color__white;
 
     @include breakpoint('medium') {
-      padding: 0 size($size__content-padding, 'medium');
+      padding-right: size($size__content-padding, 'medium');
+      padding-left: size($size__content-padding, 'medium');
     }
 
     @include breakpoint('large') {
@@ -130,6 +133,7 @@
 
   &__footer {
     grid-area: footer;
+    padding: size($size__content-padding, 'small');
     background-color: $color__off-white;
   }
 }


### PR DESCRIPTION
- Sets up the single post layout with placeholders for the items listed in #19. The issue will be closed when the individual components are finished and the final page design has been reviewed.
- Creates an include for the post image
- I decided not to refactor the content-padding into a mixin. Since it will only be used at the page level and there are enough differences in values at the various breakpoints, it made more sense to write it out in full for maximum granular control
- Note that the post image is included twice in the post layout to accommodate the tablet layout. The tablet design and desktop design could not be implemented without repeating this component due to the unknown height of the image. It is not good practice to duplicate the same item twice on the page just to adjust its position in the design, but in this instance there wasn't a way to make it work without duplication.