### PR TITLE
Refactor breakpoints & update stylelint

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -8,7 +8,17 @@
     "scss/dollar-variable-pattern": "^[a-z]+([a-z0-9-_]+[a-z0-9]+)?$",
     "scss/percent-placeholder-pattern": "^[a-z0-9]+([a-z0-9-_]+[a-z0-9]+)?$",
     "selector-class-pattern":"^(?:(?:o|c|u|t|s|is|has|_|js|qa)-)?[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*(?:__[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:--[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*)?(?:\\[.+\\])?$",
-    "max-nesting-depth": 3,
+    "max-nesting-depth": [
+      3,
+      {
+        "ignoreAtRules": [
+          "each",
+          "media",
+          "supports",
+          "include"
+        ]
+      }
+    ],
     "order/order": [
       "custom-properties",
       "dollar-variables",

--- a/assets/_sass/abstracts/_mixins.scss
+++ b/assets/_sass/abstracts/_mixins.scss
@@ -24,40 +24,34 @@
 }
 
 // Breakpoints
-$breakpoint-xlarge: 82em;
-$breakpoint-large: 48em;
-$breakpoint-medium: 33.75em;
-$breakpoint-small: 26em;
-$breakpoint-xsmall: 26em;
+// $break: Breakpoint to use
+// $dir: 'min-width' or 'max-width'
+// $until: Maximum width
+// @include breakpoint('medium');
+// @include breakpoint($break: 'medium', $until: 'large');
+// @include breakpoint($break: 'medium', $dir: 'max-width');
+@mixin breakpoint($break, $dir: 'min-width', $until: null) {
+  @if not map-has-key($breakpoints, $break) {
+    $break: $break;
+  }
+  @else {
+    $break: map-get($breakpoints, $break);
+  }
 
-@mixin breakpoint($break) {
-  @if $break==xlarge {
-    @media screen and (min-width: $breakpoint-xlarge) {
-      @content;
+  @if $break and $until {
+    @if not map-has-key($breakpoints, $until) {
+      $until: $until;
     }
-  }
-  @else if $break==large {
-    @media screen and (min-width: $breakpoint-large) {
-      @content;
+    @else {
+      $until: map-get($breakpoints, $until);
     }
-  }
-  @else if $break==medium {
-    @media screen and (min-width: $breakpoint-medium) {
-      @content;
-    }
-  }
-  @else if $break==small {
-    @media screen and (min-width: $breakpoint-small) {
-      @content;
-    }
-  }
-  @else if $break==xsmall {
-    @media screen and (max-width: $breakpoint-xsmall) {
+
+    @media screen and (min-width: $break) and (max-width: $until) {
       @content;
     }
   }
   @else {
-    @media screen and (min-width: $break) {
+    @media screen and ($dir: $break) {
       @content;
     }
   }
@@ -114,4 +108,16 @@ $breakpoint-xsmall: 26em;
       display: none;
     }
   }
+}
+
+// Displays the dark orange sidebar in header and page footer
+@mixin orange-side-bar($direction: right, $width: 20px, $height: 200px) {
+  content: '';
+  position: absolute;
+  top: 0;
+  #{$direction}: -#{$width};
+  display: block;
+  width: $width;
+  height: $height;
+  background-color: $color__orange-dark;
 }

--- a/assets/_sass/abstracts/_variables.scss
+++ b/assets/_sass/abstracts/_variables.scss
@@ -56,6 +56,14 @@ $font__line-height-pre: 1.6;
 
 /*----------  Structure  ----------*/
 
+$breakpoints: (
+  'xlarge': 82em,
+  'large': 48em,
+  'medium': 33.75em,
+  'small': 26em,
+  'xsmall': 26em
+);
+
 $size__wrapper-max-width: (
   'small': 100%,
   'medium': calc(100% - (32px * 2)),

--- a/assets/_sass/base/_base.scss
+++ b/assets/_sass/base/_base.scss
@@ -11,40 +11,24 @@ html {
 body {
   /* Fallback for when there is no custom background color defined. */
   --breakpoint: 'xsmall';
+  $sizes: ('small', 'medium', 'large', 'xlarge');
+  @each $size in $sizes {
+    @include breakpoint($size) {
+      --breakpoint: '#{$size}';
+    }
+  }
   background: $color__background-body;
-
-  @include breakpoint('small') {
-    --breakpoint: 'small';
-  }
-
-  @include breakpoint('medium') {
-    --breakpoint: 'medium';
-  }
-
-  @include breakpoint('large') {
-    --breakpoint: 'large';
-  }
-
-  @include breakpoint('xlarge') {
-    --breakpoint: 'xlarge';
-  }
 }
 
 .wrapper {
-  max-width: size($size__wrapper-max-width, 'small');
+  $sizes: ('small', 'medium', 'large', 'xlarge');
   margin: 0 auto;
   padding: 0 size($size__wrapper-padding, 'small');
 
-  @include breakpoint('medium') {
-    max-width: size($size__wrapper-max-width, 'medium');
-    padding: 0;
-  }
-
-  @include breakpoint('large') {
-    max-width: size($size__wrapper-max-width, 'large');
-  }
-
-  @include breakpoint('xlarge') {
-    max-width: size($size__wrapper-max-width, 'xlarge');
+  @each $size in $sizes {
+    @include breakpoint($size) {
+      max-width: size($size__wrapper-max-width, $size);
+      padding: 0;
+    }
   }
 }


### PR DESCRIPTION
Updated the stylelint max-nesting rule to ignore `@` statements like include, media queries, each, etc.

Refactored the breakpoints mixin to accept two additional arguments, `$dir` and `$until`. These two arguments allow you to either switch the direction of the breakpoint (eg: `max-width: $breakpoint-medium`) or specify range between two breakpoints (eg: `(min-width: $breakpoint-medium) and (max-width: $breakpoint-large)`). This change is backwards compatible and should not break existing media queries. I also moved the breakpoint variables into `_variables.scss`