### PR TITLE
Add post title & content type styles

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -5,7 +5,7 @@ layout: default
 
   <header class="post__header">
     <h1 class="post__title" itemprop="name headline">{{ page.title | escape }}</h1>
-    Content Type<br />
+    <div class="post__content-type">Content Type</div>
   </header>
   <section class="post__meta">
     Authors<br />

--- a/assets/_js/bundle.js
+++ b/assets/_js/bundle.js
@@ -1,1 +1,6 @@
 console.log('Welcome to the CSIS Jekyll Starter kit.')
+import objectFitImages from 'object-fit-images'
+
+window.addEventListener('DOMContentLoaded', () => {
+  objectFitImages()
+})

--- a/assets/_sass/pages/_post.scss
+++ b/assets/_sass/pages/_post.scss
@@ -43,7 +43,7 @@
       @extend %page__title;
       margin: 0 0 0.5rem;
 
-      @include breakpoint($breakpoint-medium, $breakpoint-large) {
+      @include breakpoint($break: 'medium', $until: 'large') {
         padding: 0;
       }
     }

--- a/assets/_sass/pages/_post.scss
+++ b/assets/_sass/pages/_post.scss
@@ -13,7 +13,7 @@
       'sidebar sidebar'
       'content content'
       'footer footer';
-    grid-template-columns: auto 33%;
+    grid-template-columns: auto minmax(33%, 50%);
   }
   
   @include breakpoint('large') {
@@ -27,43 +27,52 @@
   
   &__header {
     grid-area: header;
-    padding: 0 size($size__content-padding, 'small');
     color: $color__white;
 
-    @include breakpoint('medium') {
-      padding: 0;
-    }
-
-    @include breakpoint('large') {
-      padding: 0 size($size__content-padding, 'large');
+    #{$post}__title,
+    #{$post}__content-type {
+      $sizes: ('small', 'large', 'xlarge');
+      @each $size in $sizes {
+        @include breakpoint($size) {
+          padding: 0 size($size__content-padding, $size);
+        }
+      }
     }
 
     #{$post}__title {
       @extend %page__title;
-      margin: 0 0 0.5rem 0;
+      margin: 0 0 0.5rem;
+
+      @include breakpoint($breakpoint-medium, $breakpoint-large) {
+        padding: 0;
+      }
     }
 
+    #{$post}__content-type {
+      position: relative;
+      padding-top: 0.5rem;
+      padding-bottom: 0.5rem;
+      background-color: $color__orange;
+      @include box-shadow(0,2px,11px,3px, rgba($color__black, 0.16), false);
+
+      &::after {
+        @include breakpoint('medium') {
+          @include orange-side-bar();
+        }
+      }
+    }
   }
 
   &__meta {
+    $sizes: ('medium', 'large', 'xlarge');
     grid-area: meta;
     padding: size($size__content-padding, 'small');
     background-color: $color__white;
 
-    @include breakpoint('medium') {
-      padding: 1rem size($size__content-padding, 'medium');
-    }
-
-    @include breakpoint('large') {
-      padding: 1rem size($size__content-padding, 'large');
-    }
-  }
-
-  &__header,
-  &__meta {
-    @include breakpoint('xlarge') {
-      $max-width: size($size__content-max-width, 'xlarge');
-      padding: 1rem calc((100% - #{$max-width}) / 2);
+    @each $size in $sizes {
+      @include breakpoint($size) {
+        padding: 1rem size($size__content-padding, $size);
+      }
     }
   }
 
@@ -93,7 +102,11 @@
   &__img {
     position: relative;
     display: block;
+    object-fit: cover;
+    width: 100%;
     max-width: 100%;
+    height: 100%;
+    max-height: 100%;
     line-height: 1;
   }
 

--- a/assets/_sass/pages/_post.scss
+++ b/assets/_sass/pages/_post.scss
@@ -3,6 +3,8 @@
 ============================*/
 
 .post {
+  $post: &;
+
   @include breakpoint('medium') {
     display: grid;
     grid-template-areas:
@@ -35,6 +37,12 @@
     @include breakpoint('large') {
       padding: 0 size($size__content-padding, 'large');
     }
+
+    #{$post}__title {
+      @extend %page__title;
+      margin: 0 0 0.5rem 0;
+    }
+
   }
 
   &__meta {

--- a/frasco.config.js
+++ b/frasco.config.js
@@ -65,6 +65,7 @@ module.exports = {
     dest: 'css',
     outputStyle: 'compressed',
     autoprefixer: {
+      grid: true,
       browsers: ['> 1%', 'last 2 versions', 'Firefox ESR']
     }
   },

--- a/gulp_tasks/sass.js
+++ b/gulp_tasks/sass.js
@@ -12,9 +12,8 @@ gulp.task('sass', ['styleLint'], function() {
     )
     .pipe(
       postcss([
-        autoprefixer({
-          browsers: config.sass.autoprefixer.browsers
-        })
+        autoprefixer(config.sass.autoprefixer),
+        require('postcss-object-fit-images')
       ])
     )
     .pipe(gulp.dest(config.assets + '/' + config.sass.dest))

--- a/package-lock.json
+++ b/package-lock.json
@@ -2648,6 +2648,45 @@
         "randomfill": "^1.0.3"
       }
     },
+    "css-font-size-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
+      "integrity": "sha1-hUh1rOmspqjS7g00WkSq6btttss=",
+      "dev": true
+    },
+    "css-font-stretch-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
+      "integrity": "sha1-UM7puboDH7XJUtRyMTnx4Qe1SxA=",
+      "dev": true
+    },
+    "css-font-style-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
+      "integrity": "sha1-XDUygT9jtKHelU0TzqhqtDM0CeQ=",
+      "dev": true
+    },
+    "css-font-weight-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
+      "integrity": "sha1-m8BGcayFvHJLV07106yWsNYE/Zc=",
+      "dev": true
+    },
+    "css-global-keywords": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
+      "integrity": "sha1-cqmupyeW0Bmx0qMlLeTlqqN+Smk=",
+      "dev": true
+    },
+    "css-list-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/css-list-helpers/-/css-list-helpers-1.0.1.tgz",
+      "integrity": "sha1-//VxkiAtuDJAxBaG+RnkSacCT30=",
+      "dev": true,
+      "requires": {
+        "tcomb": "^2.5.0"
+      }
+    },
     "css-select": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.0.2.tgz",
@@ -2667,6 +2706,12 @@
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
       "dev": true,
       "optional": true
+    },
+    "css-system-font-keywords": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
+      "integrity": "sha1-hcbwhquk6zLFcaMIav/ENLhII+0=",
+      "dev": true
     },
     "css-tree": {
       "version": "1.0.0-alpha.28",
@@ -9052,6 +9097,11 @@
         }
       }
     },
+    "object-fit-images": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/object-fit-images/-/object-fit-images-3.2.4.tgz",
+      "integrity": "sha512-G+7LzpYfTfqUyrZlfrou/PLLLAPNC52FTy5y1CBywX+1/FkxIloOyQXBmZ3Zxa2AWO+lMF0JTuvqbr7G5e5CWg=="
+    },
     "object-hash": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-1.3.0.tgz",
@@ -9409,6 +9459,23 @@
         "create-hash": "^1.1.0",
         "evp_bytestokey": "^1.0.0",
         "pbkdf2": "^3.0.3"
+      }
+    },
+    "parse-css-font": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/parse-css-font/-/parse-css-font-2.0.2.tgz",
+      "integrity": "sha1-e2CwYHBaJam5C38O1JPlgjJIplI=",
+      "dev": true,
+      "requires": {
+        "css-font-size-keywords": "^1.0.0",
+        "css-font-stretch-keywords": "^1.0.1",
+        "css-font-style-keywords": "^1.0.1",
+        "css-font-weight-keywords": "^1.0.0",
+        "css-global-keywords": "^1.0.1",
+        "css-list-helpers": "^1.0.1",
+        "css-system-font-keywords": "^1.0.0",
+        "tcomb": "^2.5.0",
+        "unquote": "^1.1.0"
       }
     },
     "parse-entities": {
@@ -10137,6 +10204,79 @@
       "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
       "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
     },
+    "postcss-object-fit-images": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-object-fit-images/-/postcss-object-fit-images-1.1.2.tgz",
+      "integrity": "sha1-i3cwQ9sUZy72zW8ssfDYsmqfVzs=",
+      "dev": true,
+      "requires": {
+        "parse-css-font": "^2.0.2",
+        "postcss": "^5.0.16",
+        "quote": "^0.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^2.2.1",
+            "escape-string-regexp": "^1.0.2",
+            "has-ansi": "^2.0.0",
+            "strip-ansi": "^3.0.0",
+            "supports-color": "^2.0.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
+            }
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "5.2.18",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+          "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^1.1.3",
+            "js-base64": "^2.1.9",
+            "source-map": "^0.5.6",
+            "supports-color": "^3.2.3"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^1.0.0"
+          }
+        }
+      }
+    },
     "postcss-reporter": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-6.0.0.tgz",
@@ -10398,6 +10538,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
+      "dev": true
+    },
+    "quote": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/quote/-/quote-0.4.0.tgz",
+      "integrity": "sha1-EIOSF/bBNiuJGUBE0psjP9fzLwE=",
       "dev": true
     },
     "randomatic": {
@@ -12584,6 +12730,12 @@
         }
       }
     },
+    "tcomb": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tcomb/-/tcomb-2.7.0.tgz",
+      "integrity": "sha1-ENYpWAQWaaXVNWe5pO6M3iKxwrA=",
+      "dev": true
+    },
     "temp-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
@@ -13181,8 +13333,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
       "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "gulp-stylelint": "^8.0.0",
     "gulp-watch": "^5.0.1",
     "imagemin-pngquant": "^6.0.0",
+    "postcss-object-fit-images": "^1.1.2",
     "prettier": "^1.14.3",
     "require-dir": "^1.1.0",
     "stylelint": "^9.6.0",
@@ -64,6 +65,7 @@
     "yargs": "^12.0.2"
   },
   "dependencies": {
+    "object-fit-images": "^3.2.4",
     "stylelint-config-sass-guidelines": "^5.2.0",
     "stylelint-scss": "^3.3.2"
   }


### PR DESCRIPTION
Adds the styles for the post title and the orange bar that holds the content type. It also fixes a bug with the feature image not being tall enough to fill the space on tablets. I also created a mixin that shows the darker orange bar hanging off the post. It was created as a mixin so it can be reused on the archive pages and in the page footer.

Note that this is dependent on the recent refactor to the breakpoints mixin (#74), so make sure that you have updated `master` before reviewing. 