### PR TITLE
Feature/dates

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username:
 
-date_format: '%B %d, %Y'
+date_format: '%B %-d, %Y'
 
 cloudinary_url: https://res.cloudinary.com/csisideaslab/image/upload/
 

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,8 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username:
 
+date_format: '%B %d, %Y'
+
 cloudinary_url: https://res.cloudinary.com/csisideaslab/image/upload/
 
 # Content types will be defined here

--- a/_data/language.yml
+++ b/_data/language.yml
@@ -13,3 +13,5 @@ page_footer:
 author_list: 'By '
 jump_to: Jump to
 about_authors: 'About the Authors'
+published: Published
+last_updated: Last Updated

--- a/_includes/date.html
+++ b/_includes/date.html
@@ -1,0 +1,11 @@
+{% assign date = post.date %}
+{% if page.date %}
+{% assign date = page.date %}
+{% endif %}
+
+<div class="date">
+  <span class="post__meta-label">
+    {{ site.data.language.published }}
+  </span>
+  {{ page.date | date: site.date_format }}
+</div>

--- a/_includes/date.html
+++ b/_includes/date.html
@@ -1,11 +1,11 @@
 {% assign date = post.date %}
 {% if page.date %}
-{% assign date = page.date %}
+  {% assign date = page.date %}
 {% endif %}
 
 <div class="date">
   <span class="post__meta-label">
     {{ site.data.language.published }}
   </span>
-  {{ page.date | date: site.date_format }}
+  {{ date | date: site.date_format }}
 </div>

--- a/_includes/last-updated.html
+++ b/_includes/last-updated.html
@@ -1,0 +1,9 @@
+
+{% if page.last-modified-date %}
+  <div class="last-modified">
+    <span class="post__meta-label">
+      {{ site.data.language.last_updated }}
+    </span>
+      {{ page.last-modified-date | date: site.date_format }}
+  </div>
+{% endif %}

--- a/_includes/last-updated.html
+++ b/_includes/last-updated.html
@@ -3,11 +3,9 @@
   {% assign last_updated = post.last-modified-date %}
 {% endif %}
 
-<!-- {% if page.last-modified-date %} -->
-  <div class="last-modified">
-    <span class="post__meta-label">
-      {{ site.data.language.last_updated }}
-    </span>
-      {{ last_updated | date: site.date_format }}
-  </div>
-<!-- {% endif %} -->
+<div class="last-modified">
+  <span class="post__meta-label">
+    {{ site.data.language.last_updated }}
+  </span>
+    {{ last_updated | date: site.date_format }}
+</div>

--- a/_includes/last-updated.html
+++ b/_includes/last-updated.html
@@ -1,13 +1,13 @@
-{% assign last_updated_date = post.last-modified-date %}
-{% if page.last-updated-date %}
-  {% assign last_updated_date = page.last-modified-date %}
+{% assign last_updated = page.last-modified-date %}
+{% if post.last-modified-date %}
+  {% assign last_updated = post.last-modified-date %}
 {% endif %}
 
-{% if last_updated_date %}
+<!-- {% if page.last-modified-date %} -->
   <div class="last-modified">
     <span class="post__meta-label">
       {{ site.data.language.last_updated }}
     </span>
-      {{ last_updated_date | date: site.date_format }}
+      {{ last_updated | date: site.date_format }}
   </div>
-{% endif %}
+<!-- {% endif %} -->

--- a/_includes/last-updated.html
+++ b/_includes/last-updated.html
@@ -1,9 +1,13 @@
+{% assign last_updated_date = post.last-modified-date %}
+{% if page.last-updated-date %}
+  {% assign last_updated_date = page.last-modified-date %}
+{% endif %}
 
-{% if page.last-modified-date %}
+{% if last_updated_date %}
   <div class="last-modified">
     <span class="post__meta-label">
       {{ site.data.language.last_updated }}
     </span>
-      {{ page.last-modified-date | date: site.date_format }}
+      {{ last_updated_date | date: site.date_format }}
   </div>
 {% endif %}

--- a/_includes/post-block.html
+++ b/_includes/post-block.html
@@ -8,8 +8,8 @@
       {{ post.title | escape }}
     </a></h2>
       {%- include authors-list.html authors=post.authors -%}
-      {{page.authors}}
-      Date<br />
+      {%- include date.html -%}
+      {%- include last-updated.html -%}
   </header>
   {% if include.hide_excerpt != true %}
     <section class="post-block__content">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -15,8 +15,8 @@ layout: default
       {%- for post in site.posts -%}
       <li>
         {%- include authors-list.html -%}
-        {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
-        <span class="post-meta">{{ post.date | date: date_format }}</span>
+        {%- include date.html -%}
+        {%- include last-updated.html -%}
         <h3>
           <a class="post-link" href="{{ post.url | relative_url }}">
             {{ post.title | escape }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,9 +9,8 @@ layout: default
   </header>
   <section class="post__meta">
     {%- include authors-list.html -%}
-    Published<br />
-    <span class="post__meta-label">Last Updated:</span> {{ page.last-modified-date | date: '%B %d, %Y' }}<br />
-    <span class="post__meta-label">Last Updated:</span> {{ page.last-modified-date }}<br />
+    {%- include date.html -%}
+    {%- include last-updated.html -%}
     Photo Caption
     Social Share
   </section>


### PR DESCRIPTION
closes #24 
- Displays `last-updated` and `published` on the respective pages: archive, page
- Just a note: there's a bit of a discrepancy in the labeling, for future reference. To get the date that the page it was last modified uses `page.last-modified-date`, which is a function of jekyll. The term itself is labeled as "Last Updated" both in the include and in the user-facing label.