### PR TITLE
Fix/glossary

### DIFF
--- a/_includes/glossary-jump-menu.html
+++ b/_includes/glossary-jump-menu.html
@@ -5,7 +5,7 @@
   {% if glossary_letters contains letter %}
     {% assign has_content = has_content | push: "enabled" %}
   {% else %}
-    {% assign has_content = has_content | push: "disable" %}
+    {% assign has_content = has_content | push: "disabled" %}
   {% endif %}
 {% endfor %}
 <div  class="{{ class }}__jump-menu active">

--- a/_layouts/glossary.html
+++ b/_layouts/glossary.html
@@ -23,8 +23,10 @@ layout: default
           <div class="{{ class }}__section-header" id="{{ this_letter }}">
             <div class="container">
             <h2>{{ this_letter }}</h2>
-              {% include back-to-top.html %}
-            </div>
+               {% if forloop.index !=1 %}
+                 {% include back-to-top.html %}
+               {% endif %}
+           </div>
           </div>
           <section class="page__content">
 


### PR DESCRIPTION
I had a typo: "disable" should have been "disabled"

Also, here's an optional commit that has a conditional on rendering that first "back-to-top"

On my previous PR I forgot to explain that I'm using `&:not(.enabled)` and `&:not(.disabled)` because the stye linter seemed to have a problem with my compound selectors `&-letters a{**&.**disabled}` or `&-letters a{**&.**enabled}` ([link](https://github.com/CSIS-iLab/on-the-radar/blob/20444b1c97f7870fe040e8e5cf32c6151dc40680/assets/_sass/pages/_glossary.scss#L54))