### PR TITLE
Adjust padding and bg color on post footer to match mockups

### DIFF
--- a/assets/_sass/pages/_post.scss
+++ b/assets/_sass/pages/_post.scss
@@ -152,7 +152,31 @@
 
   &__footer {
     grid-area: footer;
-    padding: content-padding('small');
+    padding-top: 2rem;
+    background-color: $color__white;
+
+    > *:not(.post__related-block) {
+      padding: content-padding('small');
+      
+      @include breakpoint('medium') {
+        padding-right: content-padding('medium');
+        padding-left: content-padding('medium');
+      }
+
+      @include breakpoint('large') {
+        padding-right: content-padding('large');
+        padding-left: content-padding('large');
+      }
+
+      @include breakpoint('xlarge') {
+        padding-right: content-padding('xlarge');
+        padding-left: content-padding('xlarge');
+      }
+    }
+  }
+
+  &__related-block {
+    padding: 2rem;
     background-color: $color__off-white;
   }
 


### PR DESCRIPTION
I originally set this up incorrectly. The author & social share should be on the white background and be the same width as the rest of the content. This moves the gray background so it is behind the related block only and updates the padding accordingly.

Note that the social share text is stuck on the left side because that component hasn't been built yet.