### PR TITLE
fix/page-header

### DIFF
--- a/_includes/page-header.html
+++ b/_includes/page-header.html
@@ -7,7 +7,7 @@
   {%- endif -%}
 
   {% assign content = content | strip_newlines %}
-  {%- if content != '' and page.permalink !== '/about/'-%}
+  {%- if content != '' and page.layout != 'page'-%}
     <div class="page__desc">{{ content }}</div>
   {%- endif -%}
   {%- if page.social_in_header -%}

--- a/_includes/page-header.html
+++ b/_includes/page-header.html
@@ -7,8 +7,8 @@
   {%- endif -%}
 
   {% assign content = content | strip_newlines %}
-  {%- if content != '' -%}
-  <div class="page__desc">{{ content }}</div>
+  {%- if content != '' and page.permalink !== '/about/'-%}
+    <div class="page__desc">{{ content }}</div>
   {%- endif -%}
   {%- if page.social_in_header -%}
     Social Share Component


### PR DESCRIPTION
Fixes page header so that it doesn't display all content on the about page. later edits to about page will be in a different PR.

* Of course this isn't really necessary if there's going to another layout file for the about page, like what was done for oceans!