### PR TITLE
feature/categories-link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,11 +10,13 @@ date_format: '%B %-d, %Y'
 
 search_briefs_url: issue-briefs/?brief_type=
 
+search_briefs_details_url: /issue-briefs/?details.
+
+search_analysis_url: /analysis/?categories=
+
 cloudinary_url: https://res.cloudinary.com/csisideaslab/image/upload/
 
 keyword_url: /search/?keywords=
-
-search_url: /search/?query=
 
 # Content types will be defined here
 collections:

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ date_format: '%B %-d, %Y'
 
 search_briefs_url: issue-briefs/?brief_type=
 
-search_brief_details_url: /issue-briefs/?details.
+search_briefs_details_url: /issue-briefs/?details.
 
 search_categories_url: /analysis/?categories=
 

--- a/_config.yml
+++ b/_config.yml
@@ -14,6 +14,8 @@ cloudinary_url: https://res.cloudinary.com/csisideaslab/image/upload/
 
 keyword_url: /search/?keywords=
 
+search_url: /search/?query=
+
 # Content types will be defined here
 collections:
   posts:

--- a/_config.yml
+++ b/_config.yml
@@ -10,9 +10,9 @@ date_format: '%B %-d, %Y'
 
 search_briefs_url: issue-briefs/?brief_type=
 
-search_briefs_details_url: /issue-briefs/?details.
+search_brief_details_url: /issue-briefs/?details.
 
-search_analysis_url: /analysis/?categories=
+search_categories_url: /analysis/?categories=
 
 cloudinary_url: https://res.cloudinary.com/csisideaslab/image/upload/
 

--- a/_includes/post-details.html
+++ b/_includes/post-details.html
@@ -11,7 +11,7 @@
     <ul class="post-details">
       <li class="post-details subtitle">{{ site.data.language.details.categories }}</li>
       {% for detail in details %}
-        <li><a href="{{ site.search_url | append: detail | relative_url }}">{{ detail }}</a></li>
+        <li><a href="{{ site.search_analysis_url | append: detail | relative_url }}">{{ detail }}</a></li>
       {% endfor %}
     </ul>
   {% else %}
@@ -26,7 +26,8 @@
         <ul class="post-details">
           <li class="post-details subtitle">{{ detail[0] | replace: "_", " " }}</li>
           {% for subdetail in detail[1] %}
-            <li>{{ subdetail }}</li>
+            {% assign brief_search_slug = detail[0] | append: "=" | append: subdetail %}
+            <li><a href="{{ site.search_briefs_details_url | append: brief_search_slug }}">{{ subdetail }}</a></li>
           {% endfor %}
         </ul>
       {% endif %}

--- a/_includes/post-details.html
+++ b/_includes/post-details.html
@@ -27,7 +27,7 @@
           <li class="post-details subtitle">{{ detail[0] | replace: "_", " " }}</li>
           {% for subdetail in detail[1] %}
             {% assign brief_search_slug = detail[0] | append: "=" | append: subdetail %}
-            <li><a href="{{ site.search_brief_details_url | append: brief_search_slug }}">{{ subdetail }}</a></li>
+            <li><a href="{{ site.search_briefs_details_url | append: brief_search_slug }}">{{ subdetail }}</a></li>
           {% endfor %}
         </ul>
       {% endif %}

--- a/_includes/post-details.html
+++ b/_includes/post-details.html
@@ -11,7 +11,7 @@
     <ul class="post-details">
       <li class="post-details subtitle">{{ site.data.language.details.categories }}</li>
       {% for detail in details %}
-        <li><a href="{{ site.search_analysis_url | append: detail | relative_url }}">{{ detail }}</a></li>
+        <li><a href="{{ site.search_categories_url | append: detail | relative_url }}">{{ detail }}</a></li>
       {% endfor %}
     </ul>
   {% else %}
@@ -27,7 +27,7 @@
           <li class="post-details subtitle">{{ detail[0] | replace: "_", " " }}</li>
           {% for subdetail in detail[1] %}
             {% assign brief_search_slug = detail[0] | append: "=" | append: subdetail %}
-            <li><a href="{{ site.search_briefs_details_url | append: brief_search_slug }}">{{ subdetail }}</a></li>
+            <li><a href="{{ site.search_brief_details_url | append: brief_search_slug }}">{{ subdetail }}</a></li>
           {% endfor %}
         </ul>
       {% endif %}

--- a/_includes/post-details.html
+++ b/_includes/post-details.html
@@ -11,7 +11,7 @@
     <ul class="post-details">
       <li class="post-details subtitle">{{ site.data.language.details.categories }}</li>
       {% for detail in details %}
-        <li>{{ detail }}</li>
+        <li><a href="{{ site.search_url | append: detail | relative_url }}">{{ detail }}</a></li>
       {% endfor %}
     </ul>
   {% else %}
@@ -26,7 +26,7 @@
         <ul class="post-details">
           <li class="post-details subtitle">{{ detail[0] | replace: "_", " " }}</li>
           {% for subdetail in detail[1] %}
-            <li>{{ subdetail }}</li>
+            <li><a href="{{ site.search_url | append: subdetail | relative_url }}">{{ subdetail }}</a></li>
           {% endfor %}
         </ul>
       {% endif %}

--- a/_includes/post-details.html
+++ b/_includes/post-details.html
@@ -26,7 +26,7 @@
         <ul class="post-details">
           <li class="post-details subtitle">{{ detail[0] | replace: "_", " " }}</li>
           {% for subdetail in detail[1] %}
-            <li><a href="{{ site.search_url | append: subdetail | relative_url }}">{{ subdetail }}</a></li>
+            <li>{{ subdetail }}</li>
           {% endfor %}
         </ul>
       {% endif %}

--- a/_posts/2018-02-14-welcome-to-jekyll.markdown
+++ b/_posts/2018-02-14-welcome-to-jekyll.markdown
@@ -2,7 +2,8 @@
 layout: post
 title: First Test Post
 date: 2018-02-13 15:56:34 +0000
-categories: jekyll update
+categories:
+- Category 1
 excerpt: 'Lorem ipsum dolor sit amet, ante rutrum in, eu ligula sem scelerisque eu
   mollis, porttitor integer nam diam pellentesque in, wisi quisque suscipit feugiat
   donec. '
@@ -22,11 +23,11 @@ image_caption: Test Image
 ---
 Tunguska event worldlets dream of the mind's eye hundreds of thousands tingling of the spine light years. Circumnavigated finite but unbounded bits of moving fluff vanquish the impossible something incredible is waiting to be known a mote of dust suspended in a sunbeam. Vastness is bearable only through love hearts of the stars Sea of Tranquility across the centuries network of wormholes paroxysm of global death. Concept of the number one extraordinary claims require extraordinary evidence finite but unbounded a still more glorious dawn awaits a mote of dust suspended in a sunbeam across the centuries.
 
-# Heading 1 
+# Heading 1
 
 Descended from astronomers tingling of the spine radio telescope Rig Veda network of wormholes invent the universe? Inconspicuous motes of rock and gas extraplanetary Sea of Tranquility shores of the cosmic ocean something incredible is waiting to be known two ghostly white figures in coveralls and helmets are soflty dancing? Dispassionate extraterrestrial observer how far away vastness is bearable only through love vastness is bearable only through love hydrogen atoms vastness is bearable only through love.
 
-### Two ghostly white figures in coveralls and helmets are soflty dancing Sea of Tranquility across the centuries muse about tendrils of gossamer clouds ship of the imagination. 
+### Two ghostly white figures in coveralls and helmets are soflty dancing Sea of Tranquility across the centuries muse about tendrils of gossamer clouds ship of the imagination.
 
 Consciousness galaxies cosmic [fugue stirred](https://google.com) by starlight realm of the galaxies hydrogen atoms? Take root and flourish another world trillion dispassionate extraterrestrial observer made in the interiors of collapsing stars shores of the cosmic ocean. Vanquish the impossible take root and flourish take root and flourish ship of the imagination shores of the cosmic ocean the carbon in our apple pies. Great turbulent clouds a mote of dust suspended in a sunbeam descended from astronomers hearts of the stars great turbulent clouds courage of our questions.
 

--- a/_posts/2018-10-31-test-jekyll-post.md
+++ b/_posts/2018-10-31-test-jekyll-post.md
@@ -9,6 +9,7 @@ authors:
 - _authors/jane-doe.md
 categories:
 - Category 1
+- Category 2
 keywords:
 - Synthetic Aperture Sonar
 - Keyword 1


### PR DESCRIPTION
Closes #28 

Only adds link to categories list, which are on analysis posts. Used `search_url` as the variable name instead of `keywords_url`, because the slug could (feasibly) be used for different components.