### PR TITLE
Feature/ie support

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "shippedProposals": true,
+        "useBuiltIns": "usage"
+      }
+    ]
+  ]
+}

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,4 @@
+> 1%
+last 2 versions
+ie 11
+Firefox ESR

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,60 +1,38 @@
 <footer class="site-footer h-card">
   <data class="u-url" href="{{ " / " | relative_url }}"></data>
-
     <img class="site-footer__csis-logo" src="{{ 'assets/images/logos/csis_logo_white.svg' | relative_url }}" alt="{{ Center for Strategic and International Studies }}" title="{{ Center for Strategic and International Studies }}" />
-
     <section class="site-footer__info">
       <div class="site-footer__about">
         <div class="site-footer__about-description">
           <h5 class="site-footer__section-title">{{site.data.language.footer.about_heading }}</h5>
             <p>{{site.data.language.footer.about_description }}</p>
         </div>
-
-
         <div class="site-footer__related">
           <h5 class="site-footer__section-title">{{ site.data.language.footer.visit_other_projects }} &mdash;</h5>
-
           <ul>
             <li>
               <a href="https://nuclearnetwork.csis.org" target="_blank"><img src="{{ 'assets/images/logos/ngnn/NGNN-logo-dark.svg' | relative_url }}" alt="{{ Next Generation Nuclear Network Logo }}" title="{{ Next Generation Nuclear Network }}" /></a>
             </li>
           </ul>
-
         </div>
       </div>
-
-
-
-
-
       <ul class="site-footer__contact">
         <li>
           <p>Address</p>
           <address>{{site.data.language.footer.address }}</address>
         </li>
-
         <li>
           <p>Email</p>
           <div><a href="mailto:{{ site.data.language.email }}?Subject={{ site.title }}">{{site.data.language.email }}</a></div>
         </li>
       </ul>
-
-
       {% include site-nav.html class="footer__nav" location="inFooter" %}
-
     </section>
-
-
-
-
-
-
   <section class="site-footer__copyright">
     <div>
       &copy;{{ site.time | date: '%Y' }} {{ site.data.language.footer.copyright }} | <a href="https://www.csis.org/privacy-policy" target="_blank">Privacy Policy</a>
     </div>
   </section>
-
 </footer>
 <script src="{{ "/assets/js/bundle.js" | relative_url }}" type="text/javascript"></script>
 {% if page.use_algolia %}
@@ -65,6 +43,3 @@
 {% elsif page.layout == 'home' %}
 <script src="{{ "/assets/js/home.js" | relative_url }}" type="text/javascript"></script>
 {% endif %}
-
-
-<script src="{{ "/assets/js/posts.js" | relative_url }}" type="text/javascript"></script>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -133,7 +133,7 @@ layout: default
     </div>
     <div class="matter__subsections">
       {%- for subsection in site.data.language.home.matter.sections -%}
-      <div class="matter__subsection">
+      <div class="matter__subsection matter__subsection--{{ forloop.index }}">
         <h3 class="subsection__title">{{ subsection.title }}</h3>
         {{ subsection.desc | markdownify }}
         {%- if subsection.footnote -%}

--- a/assets/_sass/pages/_home-ecosystem.scss
+++ b/assets/_sass/pages/_home-ecosystem.scss
@@ -52,6 +52,7 @@
 
     @include breakpoint('medium') {
       grid-gap: 12%;
+      grid-template-areas: 'conventional nuclear';
       grid-template-columns: repeat(2, 1fr);
       grid-template-rows: 1fr;
     }
@@ -109,6 +110,7 @@
 
   &__conventional {
     @include breakpoint('medium') {
+      grid-area: conventional;
       padding-right: $width;
       padding-left: 0;
       text-align: right;
@@ -125,6 +127,10 @@
   }
 
   &__nuclear {
+    @include breakpoint('medium') {
+      grid-area: nuclear;
+    }
+
     &::before {
       background-color: $color__azul;
     }
@@ -150,8 +156,8 @@
 
     @include breakpoint('large') {
       grid-gap: 4rem;
+      grid-template-areas: 'desc timeline';
       grid-template-columns: auto 25%;
-
       margin: 0 auto;
     }
 
@@ -162,6 +168,8 @@
   }
 
   &__desc {
+    grid-area: desc;
+
     p {
       margin-bottom: 0;
       @extend %home__paragraph;
@@ -199,6 +207,7 @@
 
   &__timeline {
     position: relative;
+    grid-area: timeline;
     align-self: start;
     width: 100%;
 
@@ -238,6 +247,7 @@
     position: relative;
     display: grid;
     grid-gap: $gap;
+    grid-template-areas: 'year content';
     grid-template-columns: 15% auto;
     align-content: start;
     padding-bottom: 1.5rem;
@@ -343,12 +353,17 @@
   }
 
   &__year {
+    grid-area: year;
     color: #88929a;
     font-family: $font__lato;
     font-weight: 600;
     @include font-size(14px);
     line-height: 1.29;
     text-align: right;
+  }
+
+  &__content {
+    grid-area: content;
   }
 
   &__title {

--- a/assets/_sass/pages/_home-intro.scss
+++ b/assets/_sass/pages/_home-intro.scss
@@ -96,11 +96,19 @@
   @include breakpoint('medium') {
     --margin: calc(10vw + var(--cap-half));
     grid-column-gap: 4rem;
+    grid-template-areas:
+      'title title'
+      'first second';
     grid-template-columns: repeat(2, 1fr);
   }
 
   @include breakpoint('large') {
     --margin: var(--cap-half);
+    grid-row-gap: 2rem;
+    grid-template-areas:
+      'title'
+      'first'
+      'second';
     grid-template-columns: 1fr;
   }
 
@@ -117,7 +125,7 @@
     background-color: $color__orange;
 
     @include breakpoint('medium') {
-      grid-column: 1 / -1;
+      grid-area: title;
     }
 
     &::before {
@@ -177,8 +185,18 @@
       font-weight: normal;
     }
 
+    &:first-of-type {
+      @include breakpoint('medium') {
+        grid-area: first;
+      }
+    }
+
     &:nth-of-type(2) {
       position: relative;
+
+      @include breakpoint('medium') {
+        grid-area: second;
+      }
 
       &::before {
         content: '';

--- a/assets/_sass/pages/_home-matter.scss
+++ b/assets/_sass/pages/_home-matter.scss
@@ -81,7 +81,9 @@
 
     @include breakpoint('large') {
       grid-gap: 4rem;
+      grid-template-areas: 'first second';
       grid-template-columns: repeat(2, 1fr);
+      grid-template-rows: 1fr;
       max-width: 100%;
     }
 
@@ -102,6 +104,18 @@
       + p {
         margin-top: 1rem;
       }
+    }
+  }
+
+  &__subsection--1 {
+    @include breakpoint('large') {
+      grid-area: first;
+    }
+  }
+
+  &__subsection--2 {
+    @include breakpoint('large') {
+      grid-area: second;
     }
   }
 

--- a/assets/_sass/pages/_home-proj-nav.scss
+++ b/assets/_sass/pages/_home-proj-nav.scss
@@ -120,17 +120,26 @@
     list-style: none;
 
     li {
-      display: grid;
-      grid-gap: 1rem;
       margin-bottom: 2.5rem;
-      visibility: hidden;
-      opacity: 0;
-      transition: visibility 0s 0.25s, opacity 0.3s 0.25s ease-in-out;
+
+      @supports (--css: variables) {
+        display: grid;
+        grid-gap: 1rem;
+        visibility: hidden;
+        opacity: 0;
+        transition: visibility 0s 0.25s, opacity 0.3s 0.25s ease-in-out;
+      }
 
       @include breakpoint('medium') {
-        grid-column-gap: 1.5rem;
-        grid-row-gap: 0;
-        grid-template-columns: min-content auto;
+        @supports (--css: variables) {
+          grid-column-gap: 1.5rem;
+          grid-row-gap: 0;
+          grid-template-areas:
+            'icon title'
+            '. desc';
+          grid-template-columns: max-content auto;
+          grid-template-rows: repeat(2, auto);
+        }
       }
     }
 
@@ -141,10 +150,12 @@
 
     .proj-nav__menu-icon {
       display: block;
+      grid-area: icon;
       margin: 0 auto;
     }
 
     .proj-nav__menu-title {
+      grid-area: title;
       color: #eceff2;
       font-family: $font__lato;
       font-weight: 300;
@@ -189,7 +200,7 @@
       @extend %home__subparagraph;
 
       @include breakpoint('medium') {
-        grid-column: 2;
+        grid-area: desc;
       }
     }
   }

--- a/assets/_sass/pages/_home-recent.scss
+++ b/assets/_sass/pages/_home-recent.scss
@@ -8,8 +8,8 @@
   margin-left: -50vw;
 
   @include breakpoint('medium') {
-    right: unset;
-    left: unset;
+    right: auto;
+    left: auto;
     display: flex;
     width: 100%;
     margin-right: auto;

--- a/assets/_sass/pages/_home-space.scss
+++ b/assets/_sass/pages/_home-space.scss
@@ -30,8 +30,10 @@
     }
 
     @include breakpoint('large') {
-      margin-top: -20rem; // Offset parallax effect
-      padding-top: 0;
+      @supports (--css: variables) {
+        margin-top: -20rem; // Offset parallax effect
+        padding-top: 0;
+      }
     }
   }
 

--- a/frasco.config.js
+++ b/frasco.config.js
@@ -65,8 +65,7 @@ module.exports = {
     dest: 'css',
     outputStyle: 'compressed',
     autoprefixer: {
-      grid: true,
-      browsers: ['> 1%', 'last 2 versions', 'Firefox ESR']
+      grid: true
     }
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1621,7 +1621,7 @@
     },
     "async": {
       "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
       "dev": true
     },
@@ -2239,7 +2239,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2347,7 +2348,7 @@
         },
         "yargs": {
           "version": "6.4.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
           "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
           "dev": true,
           "requires": {
@@ -2697,7 +2698,7 @@
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
@@ -3882,7 +3883,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
           "dev": true
         }
@@ -4246,6 +4247,7 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -4260,6 +4262,7 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -5329,7 +5332,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5350,12 +5354,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5368,17 +5374,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5493,7 +5502,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5505,6 +5515,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5519,6 +5530,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5629,7 +5641,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5641,6 +5654,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5761,6 +5775,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5780,6 +5795,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5808,7 +5824,8 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
@@ -5877,7 +5894,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -6074,6 +6091,7 @@
           "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
           "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "cross-spawn": "^6.0.0",
             "get-stream": "^4.0.0",
@@ -6089,6 +6107,7 @@
               "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
               "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "nice-try": "^1.0.4",
                 "path-key": "^2.0.1",
@@ -6102,6 +6121,7 @@
               "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
               "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "pump": "^3.0.0"
               }
@@ -6120,6 +6140,7 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
+          "optional": true,
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -6334,7 +6355,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
           "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
           "dev": true
         }
@@ -6595,7 +6616,7 @@
         },
         "kind-of": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
           "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
           "dev": true
         },
@@ -6656,7 +6677,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -6678,7 +6699,7 @@
         },
         "kind-of": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
           "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ=",
           "dev": true
         },
@@ -6968,6 +6989,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -7203,7 +7225,7 @@
     },
     "http-proxy": {
       "version": "1.15.2",
-      "resolved": "http://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
       "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
       "dev": true,
       "requires": {
@@ -7724,7 +7746,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-data-descriptor": {
       "version": "0.1.4",
@@ -7750,7 +7773,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-decimal": {
       "version": "1.0.3",
@@ -7979,6 +8003,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
+      "optional": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -8030,6 +8055,7 @@
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "has-symbols": "^1.0.0"
       }
@@ -8266,6 +8292,7 @@
           "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "file-type": "^5.2.0",
             "is-stream": "^1.1.0",
@@ -8276,7 +8303,8 @@
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -8558,6 +8586,7 @@
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "p-finally": "^1.0.0"
           }
@@ -8710,7 +8739,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -8845,7 +8874,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -8902,7 +8931,7 @@
       "dependencies": {
         "yargs": {
           "version": "6.6.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true,
           "requires": {
@@ -9256,7 +9285,8 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-1.1.4.tgz",
       "integrity": "sha512-FSYbp3lyKjyj3E7fMl6rYvUdX0FBXaluGqlFoYESWQlyUTq8R+wp0rkFxoYFqZlHCvsUXGjyJmLQSnXToYhOSA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "mem": {
       "version": "4.0.0",
@@ -9281,7 +9311,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -9299,7 +9329,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -9476,7 +9506,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -9495,6 +9525,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -9504,7 +9535,8 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9702,7 +9734,7 @@
       "dependencies": {
         "semver": {
           "version": "5.3.0",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true
         },
@@ -9839,7 +9871,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -10274,7 +10306,7 @@
     },
     "opn": {
       "version": "5.3.0",
-      "resolved": "http://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
       "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
       "dev": true,
       "requires": {
@@ -10444,6 +10476,7 @@
           "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "file-type": "^5.2.0",
             "is-stream": "^1.1.0",
@@ -10454,7 +10487,8 @@
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
               "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -10736,6 +10770,7 @@
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
           "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "p-finally": "^1.0.0"
           }
@@ -10843,7 +10878,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -11208,7 +11243,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
@@ -11437,7 +11472,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -11703,7 +11738,7 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
@@ -11955,7 +11990,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -12601,7 +12636,7 @@
       "dependencies": {
         "commander": {
           "version": "2.8.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
           "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
           "requires": {
             "graceful-readlink": ">= 1.0.0"
@@ -13302,7 +13337,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -13512,7 +13547,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -14487,7 +14522,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -15977,7 +16012,7 @@
     },
     "yargs-parser": {
       "version": "4.2.1",
-      "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
       "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Add IE support to home page CSS grids by adding `grid-area-templates` so Autoprefixer can do its magic.

Also added .babelrc & .browserslistrc config files, although transpiling arrow functions doesn't seem to be working (resulting in errors in IE11).