### PR TITLE
Fix author list separation items

### DIFF
--- a/_includes/authors-list.html
+++ b/_includes/authors-list.html
@@ -9,12 +9,13 @@
   {% if authors.size > 0 %}
   <div class="authors">
     <span class="post__meta-label">{{ site.data.language.author_list }}</span>
-
+      {%- assign list_break = '' -%}
+      {%- assign end_break = '' -%}
       {% if authors.size == 2 %}
-        {%- assign list_break = ' and ' -%}
+      {%- assign list_break = '&nbsp;and&nbsp;' -%}
       {% elsif authors.size >= 3 %}
-        {%- assign list_break = ', ' -%}
-        {%- assign end_break = ' and ' -%}
+      {%- assign list_break = ',&nbsp;' -%}
+      {%- assign end_break = '&nbsp;and&nbsp;' -%}
       {% endif %}
 
       {% assign penultimate = authors.size | minus: 1 %}


### PR DESCRIPTION
Fixes bug where the separator for articles with two authors was "and and" instead of "and".