### PR TITLE
Add Netlify build status badge to forestry

### DIFF
--- a/.forestry/settings.yml
+++ b/.forestry/settings.yml
@@ -4,6 +4,10 @@ auto_deploy: false
 admin_path: "/admin/"
 webhook_url: 
 sections:
+- type: document
+  label: Build Status
+  path: NETLIFY.md
+  read_only: true
 - type: jekyll-posts
   label: Analysis
   create: all

--- a/NETLIFY.md
+++ b/NETLIFY.md
@@ -1,0 +1,30 @@
+# Build Status
+
+Once you "publish" your work on Forestry, you can view the status of your website building below. Once you see "Success", your updates have been published on your website. 
+
+## Status
+
+[![Netlify Status](https://api.netlify.com/api/v1/badges/81f80e00-48aa-496f-84ca-59c8f4833d75/deploy-status)](https://app.netlify.com/sites/on-the-radar/deploys)
+
+## Status Guide
+
+Building = The update is in progress. Please do not publish again until this changes to one of the other statuses.  
+Success = The site has been updated. Your updates have now been published on your website.  
+Failed = The update did not publish. 
+
+## Troubleshooting tips
+
+Usually when a build fails, it's because content is improperly formatted.  To see what is causing the issue do the following.
+- Click on Site Activity (Circle next to the logo in the top left corner)  
+
+  ![Site Activity](https://res.cloudinary.com/csisilab/image/upload/v1578601264/site_activity_azttmh.png)
+
+- If available, click on "Show Log" and review the error message provided by Forestry to determine the error. You might need to scroll for a while until the error is visible. The error message will appear towards the end of the log.
+
+  ![Forestry Error](https://res.cloudinary.com/csisilab/image/upload/v1578601268/forestry_error_pmwzb0.png)
+
+- Go to the incorrect content and make any necessary adjustments
+- Click "Save"
+- Review the build status to confirm "Success"
+
+If this does not solve the problem, please contact the iLab for support.  


### PR DESCRIPTION
Added new NETLIFY.md file showing the Netlify build status.
Added new Build Status document to forestry settings file pointing to the NETLIFY.md file.